### PR TITLE
Implement link permissions

### DIFF
--- a/spigot/src/main/java/com/enjin/enjincraft/spigot/configuration/Conf.java
+++ b/spigot/src/main/java/com/enjin/enjincraft/spigot/configuration/Conf.java
@@ -41,6 +41,10 @@ public class Conf {
         return internalConf.getStringList(ConfPath.PERMISSION_BLACKLIST.path());
     }
 
+    public List<String> getLinkPermissions() {
+        return internalConf.getStringList(ConfPath.LINK_PERMISSIONS.path());
+    }
+
     public void setLocale(Locale locale) {
         internalConf.set(ConfPath.LOCALE.path(), locale.locale());
     }

--- a/spigot/src/main/java/com/enjin/enjincraft/spigot/configuration/ConfPath.java
+++ b/spigot/src/main/java/com/enjin/enjincraft/spigot/configuration/ConfPath.java
@@ -11,7 +11,8 @@ public enum ConfPath {
     DEBUG_PLUGIN("debug.plugin"),
     SENTRY_URL("debug.sentry"),
     TRANSLATE_CONSOLE_MESSAGES("experimental.translate-console-messages"),
-    PERMISSION_BLACKLIST("permission-blacklist");
+    PERMISSION_BLACKLIST("permission-blacklist"),
+    LINK_PERMISSIONS("link-permissions");
 
     private String path;
 

--- a/spigot/src/main/java/com/enjin/enjincraft/spigot/player/EnjPlayer.java
+++ b/spigot/src/main/java/com/enjin/enjincraft/spigot/player/EnjPlayer.java
@@ -124,9 +124,12 @@ public class EnjPlayer implements Listener {
 
         if (!listening) { service.subscribeToIdentity(identityId); }
 
-        if (!isLinked()) {
-            Bukkit.getScheduler().runTask(bootstrap.plugin(), this::removeTokenizedItems);
-            return;
+        if (isLinked()) {
+          Bukkit.getScheduler().runTask(bootstrap.plugin(), this::addLinkPermissions);
+        } else {
+          Bukkit.getScheduler().runTask(bootstrap.plugin(), this::removeTokenizedItems);
+          Bukkit.getScheduler().runTask(bootstrap.plugin(), this::removeLinkPermissions);
+          return;
         }
 
         if (identity.getWallet().getEnjAllowance() == null || identity.getWallet()
@@ -609,6 +612,14 @@ public class EnjPlayer implements Listener {
             String    tokenId = TokenUtils.getTokenID(is);
             if (!StringUtils.isEmpty(tokenId)) { inventory.setItem(i, null); }
         }
+    }
+
+    public void addLinkPermissions() {
+        bootstrap.getConfig().getLinkPermissions().forEach(perm -> globalAttachment.setPermission(perm));
+    }
+
+    public void removeLinkPermissions() {
+        bootstrap.getConfig().getLinkPermissions().forEach(perm -> globalAttachment.unsetPermission(perm));
     }
 
     public boolean isUserLoaded() {

--- a/spigot/src/main/resources/config.yml
+++ b/spigot/src/main/resources/config.yml
@@ -17,3 +17,6 @@ permission-blacklist:
   - "minecraft.command.op"
   - "minecraft.command.deop"
   - "minecraft.command.stop"
+# link-permissions:
+#   - "example.perm1"
+#   - "example.perm2"


### PR DESCRIPTION
These changes implement permissions that are granted when the player links their wallet and revoked when it's unlinked via app. Example config file:

```yaml
link-permissions:
  - "essentials.afk"
  - "essentials.ping"
```